### PR TITLE
Update README.md - Added comment about Kotlin Notebooks higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Three test scenarios are covered to benchmark the performance:
 * incremental build with ABI changes
 
 After the build finishes, open the [benchmarkResult.ipynb](benchmarkResult.ipynb) Kotlin Notebook to compare the results.
+> You must have the [Kotlin Notebook](https://blog.jetbrains.com/kotlin/2023/07/introducing-kotlin-notebook/) plugin 
+> installed in IntelliJ IDEA Ultimate to view the results.
 
 ## Project requirements
 


### PR DESCRIPTION
There was a case when a user went straight to the PyCharm to read the Notebook. That not only didn't resolve the file but also broke the metadata in the file so that it wouldn't open in IntelliJ like Kotlin Notebook anymore. We will fix this bug, but meanwhile, it's better to move the comment about the Kotlin Notebooks Plugin higher because most users currently view the .ipynb file as a Python file.